### PR TITLE
Run the docker container with current UID and GID

### DIFF
--- a/lessons/4.1-useful_in_php/Makefile
+++ b/lessons/4.1-useful_in_php/Makefile
@@ -1,6 +1,9 @@
 current-dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 SHELL = /bin/sh
 
+CURRENT_UID := $(shell id -u)
+CURRENT_GID := $(shell id -g)
+
 .PHONY: build
 build: composer/install
 
@@ -12,7 +15,7 @@ composer/install: ACTION=install
 composer/update: ACTION=update
 composer/require: ACTION=require $(module)
 composer composer/install composer/update composer/require: create_env_file
-	@docker run --rm $(INTERACTIVE) --volume $(current-dir):/app --user $(id -u):$(id -g) \
+	@docker run --rm $(INTERACTIVE) --volume $(current-dir):/app --user $(CURRENT_UID):$(CURRENT_GID) \
 		composer:2 $(ACTION) \
 			--ignore-platform-reqs \
 			--no-ansi


### PR DESCRIPTION
Before these changes, the make composer target run the container without the correct ID's of the current user:
![image](https://user-images.githubusercontent.com/62360034/188264584-9cf19d56-f6ea-414c-9546-8623a2b8297e.png)

Now, the UID and GID are correctly send to the make target:
![image](https://user-images.githubusercontent.com/62360034/188264623-889171ae-a786-4911-a381-c696b6353d2d.png)

Solution found where you expected to be 🤣: https://stackoverflow.com/a/55938766